### PR TITLE
fix: default method for function schema.

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -129,11 +129,23 @@ describe("make empty", () => {
     expect(init(z.string().default("default value"))).toBe("default value");
     expect(init(z.number().default(2))).toBe(2);
     expect(init(z.boolean().default(true))).toBe(true);
+    expect(init(z.null().default(null))).toBeNull();
+    expect(init(z.any().default({ default: true }))).toEqual({ default: true });
 
-    // return value not strict equal to default parameter.
-    const defaultValue = { default: true };
-    expect(init(z.any().default(defaultValue))).toEqual({ default: true });
-    expect(init(z.any().default(defaultValue)) === defaultValue).toBe(false);
+    const defaultFunction = (s: string) => s?.length;
+    expect(
+      init(
+        z
+          .function()
+          .args(z.string())
+          .returns(z.number())
+          .default(() => defaultFunction)
+      )
+    ).toBe(defaultFunction);
+
+    // return value for object/array/set/map not strict equal to default parameter.
+    const defaultObject = { default: true };
+    expect(init(z.any().default(defaultObject)) === defaultObject).toBe(false);
   });
 
   it("nan", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,9 @@ function make<T extends ZodTypeAny>(schema: T): unknown {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       return (..._: any[]) => make(def.returns);
     case "ZodDefault":
-      return clone(def.defaultValue());
+      return def.innerType._def.typeName === "ZodFunction"
+        ? def.defaultValue()
+        : clone(def.defaultValue());
     case "ZodNaN":
       return NaN;
     case "ZodNull":


### PR DESCRIPTION
:memo: Memo

```typescript
const defaultFunction = (s: string) => s?.length || 0;

z.function().args(z.string()).returns(z.number()).default(() => defaultFunction).parse(undefined)
// => wrapped defaultFunction

z.function().args(z.string()).returns(z.number()).default(defaultFunction).parse(undefined)
// => ZodError: [{ "code": "invalid_type", ... }]
```