### PR TITLE
fix(package.json): remove type: "commonjs"

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "node": "16.16.0",
     "npm": "8.16.0"
   },
-  "type": "commonjs",
   "exports": {
     "./package.json": "./package.json",
     "./*": {


### PR DESCRIPTION
`type: "commonjs"` in package.json breaks the build downstream when using with NextJS `13.1`, it is trying to parse the ESM version as commonJs. 

removing this field fixes the issue, and shouldn't have any negative issues as if it's missing it's assumed to be CJS.

Taken from [the node docs](https://nodejs.org/api/packages.html#type):
>If the nearest parent package.json lacks a "type" field, or contains "type": "commonjs", .js files are treated as [CommonJS](https://nodejs.org/api/modules.html). If the volume root is reached and no package.json is found, .js files are treated as [CommonJS](https://nodejs.org/api/modules.html).