### PR TITLE
Add z.string().uuid() support, fiz nullable() and nullish() and fix output type

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -16,6 +16,12 @@ describe("make empty", () => {
     expect(empty(schema)).toBeNull();
   });
 
+  it("uuid", () => {
+    const schema = z.string().uuid();
+    expect(init(schema).length).toBe(36);
+    expect(empty(schema)).toBeNull();
+  });
+
   it.each([
     ["", z.number(), 0],
     ["10-", z.number().min(10), 10],
@@ -228,17 +234,17 @@ describe("make empty", () => {
   describe("nullable", () => {
     it("string", () => {
       const schema = z.string().nullable();
-      expect(init(schema)).toBe("");
+      expect(init(schema)).toBeNull();
       expect(empty(schema)).toBeNull();
     });
     it("number", () => {
       const schema = z.number().nullable();
-      expect(init(schema)).toBe(0);
+      expect(init(schema)).toBeNull();
       expect(empty(schema)).toBeNull();
     });
     it("array", () => {
       const schema = z.array(z.string()).nullable();
-      expect(init(schema)).toStrictEqual([]);
+      expect(init(schema)).toBeNull();
       expect(empty(schema)).toStrictEqual([]);
     });
   });
@@ -246,17 +252,17 @@ describe("make empty", () => {
   describe("nullish", () => {
     it("string", () => {
       const schema = z.string().nullish();
-      expect(init(schema)).toBe("");
+      expect(init(schema)).toBeNull();
       expect(empty(schema)).toBeNull();
     });
     it("number", () => {
       const schema = z.number().nullish();
-      expect(init(schema)).toBe(0);
+      expect(init(schema)).toBeNull();
       expect(empty(schema)).toBeNull();
     });
     it("array", () => {
       const schema = z.array(z.string()).nullish();
-      expect(init(schema)).toStrictEqual([]);
+      expect(init(schema)).toBeNull();
       expect(empty(schema)).toStrictEqual([]);
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import clone from "just-clone";
-import type { ZodTypeAny, input } from "zod";
+import type { ZodTypeAny, input, output } from "zod";
 
-export function init<T extends ZodTypeAny>(schema: T): input<T> {
+export function init<T extends ZodTypeAny>(schema: T): output<T> {
   const def = schema._def;
   switch (def.typeName) {
     case "ZodObject": {
@@ -13,8 +13,16 @@ export function init<T extends ZodTypeAny>(schema: T): input<T> {
     }
     case "ZodRecord":
       return {};
-    case "ZodString":
+    case "ZodString": {
+      if (def.checks) {
+        for (const check of def.checks) {
+          if (check.kind === "uuid") {
+            return crypto.randomUUID();
+          }
+        }
+      }
       return "";
+    }
     case "ZodNumber":
       for (const check of def.checks || []) {
         if (["min", "max"].includes(check.kind)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,10 @@ import type { ZodTypeAny, input, output } from "zod";
 
 export function init<T extends ZodTypeAny>(schema: T): output<T> {
   const def = schema._def;
+  if (schema.isNullable() && def.typeName !== "ZodDefault") {
+    return null;
+  }
+
   switch (def.typeName) {
     case "ZodObject": {
       const outputObject: Record<string, unknown> = {};
@@ -76,7 +80,6 @@ export function init<T extends ZodTypeAny>(schema: T): output<T> {
     case "ZodNull":
     case "ZodAny":
       return null;
-    case "ZodNullable":
     case "ZodOptional":
       return init(def.innerType);
     // case "ZodUndefined":
@@ -84,9 +87,6 @@ export function init<T extends ZodTypeAny>(schema: T): output<T> {
     // case "ZodUnknown":
     // case "ZodNever":
     default:
-      if (schema.isNullable()) {
-        return null;
-      }
       return undefined;
   }
 }


### PR DESCRIPTION
This PR adds support for z.string().uuid(). Now the `init` function generates a random uuid in this scenario.

Also, it fixes the behavior of the `nullable()` and `nullish()` validations, to return `null` values instead of empty ones.