### PR TITLE
fix: incorrect exports path in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,8 +93,8 @@
     "./package.json": "./package.json",
     ".": {
       "node": {
-        "types": "./dist/mjs/index.d.ts",
-        "import": "./dist/mjs/index.js",
+        "types": "./dist/esm/index.d.ts",
+        "import": "./dist/esm/index.js",
         "default": "./dist/cjs/index.js"
       },
       "default": {


### PR DESCRIPTION
Fixes #28

Update `zod-empty`’s `package.json` to fix incorrect `exports` paths (`./dist/mjs` → `./dist/esm`), allowing the test to run properly.