### PR TITLE
ci: add trusted publishing with provenance support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm test -- --run
+
+      - name: Release
+        run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     ]
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "engines": {
     "node": ">=20.10.0",


### PR DESCRIPTION
## Summary

- Add `release.yml` workflow for automated releases on main branch push
- Enable npm provenance with OIDC authentication (trusted publishing)
- Add `provenance: true` to `publishConfig`

## Setup Required

After merging, link the npm package to this GitHub repository on npmjs.com:
1. Go to https://www.npmjs.com/package/zod-empty/access
2. Configure "Publishing access" to allow GitHub Actions