### PR TITLE
fix: skip npm verifyConditions for trusted publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
     "src/index.ts"
   ],
   "release": {
+    "verifyConditions": [
+      "@semantic-release/changelog",
+      "@semantic-release/github",
+      "@semantic-release/git"
+    ],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",


### PR DESCRIPTION
## Summary

Skip `@semantic-release/npm` from verifyConditions to allow OIDC-based trusted publishing without npm token validation.

The npm provenance/trusted publishing works at publish time via OIDC, but `npm whoami` check fails without a token.