### PR TITLE
fix: remove registry-url to enable OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           node-version: 24
           cache: npm
-          registry-url: "https://registry.npmjs.org"
 
       - run: npm ci
 


### PR DESCRIPTION
## Summary

Remove `registry-url` from `actions/setup-node` step.

According to [semantic-release documentation](https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions):

> "Do not set the registry-url option in the actions/setup-node step when using semantic-release for npm publishing. The registry-url option causes setup-node to create an .npmrc file that can conflict with semantic-release's npm authentication mechanism, leading to EINVALIDNPMTOKEN errors even when your token is valid."

This was causing the OIDC token exchange to fail during `verifyConditions`.