### PR TITLE
fix: upgrade to actions v6 and remove NODE_AUTH_TOKEN for OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -35,4 +35,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
-          NODE_AUTH_TOKEN: ""


### PR DESCRIPTION
## Summary

- Upgrade actions/checkout and actions/setup-node from v4 to v6 (Node 24 support)
- Remove `NODE_AUTH_TOKEN: ""` which was incorrectly blocking OIDC authentication

## Background

The Node.js 20 deprecation warning indicated the actions were running on an older Node runtime. Additionally, setting `NODE_AUTH_TOKEN: ""` actually prevents OIDC from working because npm attempts to use the empty token instead of OIDC.

References:
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- https://dev.to/zhangjintao/from-deprecated-npm-classic-tokens-to-oidc-trusted-publishing-a-cicd-troubleshooting-journey-4h8b