### PR TITLE
docs: normalize CHANGELOG headings for changesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,211 +1,185 @@
-# [2.1.0](https://github.com/toiroakr/zod-empty/compare/v2.0.0...v2.1.0) (2026-04-07)
+# zod-empty
 
+## [2.1.0](https://github.com/toiroakr/zod-empty/compare/v2.0.0...v2.1.0) (2026-04-07)
 
 ### Bug Fixes
 
-* clear NODE_AUTH_TOKEN for OIDC trusted publishing ([a524cd1](https://github.com/toiroakr/zod-empty/commit/a524cd139e62943e10e956a97065d40e5b0b3781))
-* clear NODE_AUTH_TOKEN for OIDC trusted publishing ([#40](https://github.com/toiroakr/zod-empty/issues/40)) ([c10a555](https://github.com/toiroakr/zod-empty/commit/c10a555cca4eb2c84298676defc8505f434bda0a))
-* remove registry-url to enable OIDC trusted publishing ([c96a381](https://github.com/toiroakr/zod-empty/commit/c96a381f0fdb0a9e78370193c144a04c2f635c39))
-* remove registry-url to enable OIDC trusted publishing ([#39](https://github.com/toiroakr/zod-empty/issues/39)) ([2d179f1](https://github.com/toiroakr/zod-empty/commit/2d179f172663a57f0a8dc1598f4e7e53d6d32957))
-* skip npm verifyConditions for trusted publishing ([311f0bd](https://github.com/toiroakr/zod-empty/commit/311f0bd9c24133238aba9e748dd3fe1b6fd4f91b))
-* skip npm verifyConditions for trusted publishing ([#37](https://github.com/toiroakr/zod-empty/issues/37)) ([3424393](https://github.com/toiroakr/zod-empty/commit/3424393f7713a80a17388fbea8ee11526d0ec127))
-* upgrade @semantic-release/npm to v13 for OIDC support ([9c386d2](https://github.com/toiroakr/zod-empty/commit/9c386d2a44164df1d2f9bb17a4ce84ecbd82bdb2))
-* upgrade @semantic-release/npm to v13 for OIDC trusted publishing ([#38](https://github.com/toiroakr/zod-empty/issues/38)) ([e78a7c2](https://github.com/toiroakr/zod-empty/commit/e78a7c288a0d6740b6e39b2dac9f8c17649225bf))
-* upgrade semantic-release to v25 for OIDC support ([5fe3d1c](https://github.com/toiroakr/zod-empty/commit/5fe3d1c614cc919625cfd8fce564c8c7af1fb8f0))
-* upgrade semantic-release to v25 for OIDC support ([#42](https://github.com/toiroakr/zod-empty/issues/42)) ([be89c10](https://github.com/toiroakr/zod-empty/commit/be89c109cb59f686808906fffdeec15d8f2532cf))
-* upgrade to actions v6 and remove NODE_AUTH_TOKEN ([25b12f1](https://github.com/toiroakr/zod-empty/commit/25b12f1489d4000e2abc2633a2b5fed991ded788))
-* upgrade to actions v6 and remove NODE_AUTH_TOKEN for OIDC ([#41](https://github.com/toiroakr/zod-empty/issues/41)) ([1be270b](https://github.com/toiroakr/zod-empty/commit/1be270b18f3681733efc2d3c86902370f705080e))
-
-
-### Features
-
-* add support for TypeScript 6 in peerDependencies ([e806055](https://github.com/toiroakr/zod-empty/commit/e8060553fc390164fac96f209b057446c922d8b1))
-* add TypeScript 6 support ([#35](https://github.com/toiroakr/zod-empty/issues/35)) ([f63be85](https://github.com/toiroakr/zod-empty/commit/f63be85709eaa853b1ec8d9296a4e2e2ae73b43d))
-* upgrade devDependencies TypeScript to 6.0.2 ([0aa90f9](https://github.com/toiroakr/zod-empty/commit/0aa90f9d945ed1df6cbdce981aece33f05970e9c))
-
-# [1.5.0](https://github.com/toiroakr/zod-empty/compare/v1.4.5...v1.5.0) (2025-07-28)
-
+- clear NODE_AUTH_TOKEN for OIDC trusted publishing ([a524cd1](https://github.com/toiroakr/zod-empty/commit/a524cd139e62943e10e956a97065d40e5b0b3781))
+- clear NODE_AUTH_TOKEN for OIDC trusted publishing ([#40](https://github.com/toiroakr/zod-empty/issues/40)) ([c10a555](https://github.com/toiroakr/zod-empty/commit/c10a555cca4eb2c84298676defc8505f434bda0a))
+- remove registry-url to enable OIDC trusted publishing ([c96a381](https://github.com/toiroakr/zod-empty/commit/c96a381f0fdb0a9e78370193c144a04c2f635c39))
+- remove registry-url to enable OIDC trusted publishing ([#39](https://github.com/toiroakr/zod-empty/issues/39)) ([2d179f1](https://github.com/toiroakr/zod-empty/commit/2d179f172663a57f0a8dc1598f4e7e53d6d32957))
+- skip npm verifyConditions for trusted publishing ([311f0bd](https://github.com/toiroakr/zod-empty/commit/311f0bd9c24133238aba9e748dd3fe1b6fd4f91b))
+- skip npm verifyConditions for trusted publishing ([#37](https://github.com/toiroakr/zod-empty/issues/37)) ([3424393](https://github.com/toiroakr/zod-empty/commit/3424393f7713a80a17388fbea8ee11526d0ec127))
+- upgrade @semantic-release/npm to v13 for OIDC support ([9c386d2](https://github.com/toiroakr/zod-empty/commit/9c386d2a44164df1d2f9bb17a4ce84ecbd82bdb2))
+- upgrade @semantic-release/npm to v13 for OIDC trusted publishing ([#38](https://github.com/toiroakr/zod-empty/issues/38)) ([e78a7c2](https://github.com/toiroakr/zod-empty/commit/e78a7c288a0d6740b6e39b2dac9f8c17649225bf))
+- upgrade semantic-release to v25 for OIDC support ([5fe3d1c](https://github.com/toiroakr/zod-empty/commit/5fe3d1c614cc919625cfd8fce564c8c7af1fb8f0))
+- upgrade semantic-release to v25 for OIDC support ([#42](https://github.com/toiroakr/zod-empty/issues/42)) ([be89c10](https://github.com/toiroakr/zod-empty/commit/be89c109cb59f686808906fffdeec15d8f2532cf))
+- upgrade to actions v6 and remove NODE_AUTH_TOKEN ([25b12f1](https://github.com/toiroakr/zod-empty/commit/25b12f1489d4000e2abc2633a2b5fed991ded788))
+- upgrade to actions v6 and remove NODE_AUTH_TOKEN for OIDC ([#41](https://github.com/toiroakr/zod-empty/issues/41)) ([1be270b](https://github.com/toiroakr/zod-empty/commit/1be270b18f3681733efc2d3c86902370f705080e))
 
 ### Features
 
-* update version to 2.0.0 and enhance ZodDefWithShape interface ([6eb0bab](https://github.com/toiroakr/zod-empty/commit/6eb0bab031437cb8fa8768f45af3ad6955efceeb))
+- add support for TypeScript 6 in peerDependencies ([e806055](https://github.com/toiroakr/zod-empty/commit/e8060553fc390164fac96f209b057446c922d8b1))
+- add TypeScript 6 support ([#35](https://github.com/toiroakr/zod-empty/issues/35)) ([f63be85](https://github.com/toiroakr/zod-empty/commit/f63be85709eaa853b1ec8d9296a4e2e2ae73b43d))
+- upgrade devDependencies TypeScript to 6.0.2 ([0aa90f9](https://github.com/toiroakr/zod-empty/commit/0aa90f9d945ed1df6cbdce981aece33f05970e9c))
+
+## [1.5.0](https://github.com/toiroakr/zod-empty/compare/v1.4.5...v1.5.0) (2025-07-28)
+
+### Features
+
+- update version to 2.0.0 and enhance ZodDefWithShape interface ([6eb0bab](https://github.com/toiroakr/zod-empty/commit/6eb0bab031437cb8fa8768f45af3ad6955efceeb))
 
 ## [1.4.5](https://github.com/toiroakr/zod-empty/compare/v1.4.4...v1.4.5) (2025-04-29)
 
-
 ### Bug Fixes
 
-* incorrect exports path in `package.json` ([#29](https://github.com/toiroakr/zod-empty/issues/29)) ([69603a3](https://github.com/toiroakr/zod-empty/commit/69603a3201a61a787cf64938a04a6d5c69ee7394)), closes [#28](https://github.com/toiroakr/zod-empty/issues/28)
-* update module exports ([64bac3f](https://github.com/toiroakr/zod-empty/commit/64bac3f4793792ab585118e9fb2bb39689c53697))
+- incorrect exports path in `package.json` ([#29](https://github.com/toiroakr/zod-empty/issues/29)) ([69603a3](https://github.com/toiroakr/zod-empty/commit/69603a3201a61a787cf64938a04a6d5c69ee7394)), closes [#28](https://github.com/toiroakr/zod-empty/issues/28)
+- update module exports ([64bac3f](https://github.com/toiroakr/zod-empty/commit/64bac3f4793792ab585118e9fb2bb39689c53697))
 
 ## [1.4.4](https://github.com/toiroakr/zod-empty/compare/v1.4.3...v1.4.4) (2025-04-22)
 
-
 ### Bug Fixes
 
-* export js ([9e3cee2](https://github.com/toiroakr/zod-empty/commit/9e3cee2709fe1f4c62b81c0ad01f8f1ae2082444))
+- export js ([9e3cee2](https://github.com/toiroakr/zod-empty/commit/9e3cee2709fe1f4c62b81c0ad01f8f1ae2082444))
 
 ## [1.4.3](https://github.com/toiroakr/zod-empty/compare/v1.4.2...v1.4.3) (2025-04-22)
 
-
 ### Bug Fixes
 
-* package ([b444070](https://github.com/toiroakr/zod-empty/commit/b444070c72a79e4d198fefbc20886cddf3f161b3))
+- package ([b444070](https://github.com/toiroakr/zod-empty/commit/b444070c72a79e4d198fefbc20886cddf3f161b3))
 
 ## [1.4.2](https://github.com/toiroakr/zod-empty/compare/v1.4.1...v1.4.2) (2025-04-22)
 
-
 ### Bug Fixes
 
-* update package.json ([fbe3873](https://github.com/toiroakr/zod-empty/commit/fbe3873e1674d35098ba6ca0c3cb3d5910d27386))
+- update package.json ([fbe3873](https://github.com/toiroakr/zod-empty/commit/fbe3873e1674d35098ba6ca0c3cb3d5910d27386))
 
 ## [1.4.1](https://github.com/toiroakr/zod-empty/compare/v1.4.0...v1.4.1) (2025-03-08)
 
+### Bug Fixes
+
+- improve type ([b950695](https://github.com/toiroakr/zod-empty/commit/b9506958c6f814a5405b3eaa08a218bcad1e28c1))
+- improve type ([#27](https://github.com/toiroakr/zod-empty/issues/27)) ([f9f95a5](https://github.com/toiroakr/zod-empty/commit/f9f95a51b2cb921985b96d7b0c95a183f7c27c87))
+
+## [1.4.0](https://github.com/toiroakr/zod-empty/compare/v1.3.4...v1.4.0) (2025-03-07)
 
 ### Bug Fixes
 
-* improve type ([b950695](https://github.com/toiroakr/zod-empty/commit/b9506958c6f814a5405b3eaa08a218bcad1e28c1))
-* improve type ([#27](https://github.com/toiroakr/zod-empty/issues/27)) ([f9f95a5](https://github.com/toiroakr/zod-empty/commit/f9f95a51b2cb921985b96d7b0c95a183f7c27c87))
-
-# [1.4.0](https://github.com/toiroakr/zod-empty/compare/v1.3.4...v1.4.0) (2025-03-07)
-
-
-### Bug Fixes
-
-* bigint bug ([24517cf](https://github.com/toiroakr/zod-empty/commit/24517cfa7cd002d1af3123f93cc155626d6d368d))
-* files ([907114d](https://github.com/toiroakr/zod-empty/commit/907114dd0b8bdc2b1e3f523856fa39c9a9109810))
-
+- bigint bug ([24517cf](https://github.com/toiroakr/zod-empty/commit/24517cfa7cd002d1af3123f93cc155626d6d368d))
+- files ([907114d](https://github.com/toiroakr/zod-empty/commit/907114dd0b8bdc2b1e3f523856fa39c9a9109810))
 
 ### Features
 
-* support coerce. ([7a0e1a6](https://github.com/toiroakr/zod-empty/commit/7a0e1a6fea164cf568f91f67f12d63a6af68e576))
+- support coerce. ([7a0e1a6](https://github.com/toiroakr/zod-empty/commit/7a0e1a6fea164cf568f91f67f12d63a6af68e576))
 
 ## [1.3.4](https://github.com/toiroakr/zod-empty/compare/v1.3.3...v1.3.4) (2025-01-10)
 
-
 ### Bug Fixes
 
-* test action fails on PR from forks ([4329f2c](https://github.com/toiroakr/zod-empty/commit/4329f2cbbb7d43ae2059935f98c95bdade9a7aef))
+- test action fails on PR from forks ([4329f2c](https://github.com/toiroakr/zod-empty/commit/4329f2cbbb7d43ae2059935f98c95bdade9a7aef))
 
 ## [1.3.3](https://github.com/toiroakr/zod-empty/compare/v1.3.2...v1.3.3) (2025-01-10)
 
-
 ### Bug Fixes
 
-* test ([4465ca7](https://github.com/toiroakr/zod-empty/commit/4465ca7b24a7026823e53ec187cf88c05a9d41d3))
-* update init function to handle nullable types and add UUID test case ([fdada69](https://github.com/toiroakr/zod-empty/commit/fdada69528696f7af564d904a49c3cec0827f5e7))
-* update init function to return output type and handle UUID generation for ZodString ([9d7a1b7](https://github.com/toiroakr/zod-empty/commit/9d7a1b72ffde53e150db79c73476a204452f4ba4))
+- test ([4465ca7](https://github.com/toiroakr/zod-empty/commit/4465ca7b24a7026823e53ec187cf88c05a9d41d3))
+- update init function to handle nullable types and add UUID test case ([fdada69](https://github.com/toiroakr/zod-empty/commit/fdada69528696f7af564d904a49c3cec0827f5e7))
+- update init function to return output type and handle UUID generation for ZodString ([9d7a1b7](https://github.com/toiroakr/zod-empty/commit/9d7a1b72ffde53e150db79c73476a204452f4ba4))
 
 ## [1.3.2](https://github.com/toiroakr/zod-empty/compare/v1.3.1...v1.3.2) (2025-01-08)
 
-
 ### Bug Fixes
 
-* empty effect ([7742b63](https://github.com/toiroakr/zod-empty/commit/7742b63b90c65d20f5b10da80428e0cbc48c5939))
+- empty effect ([7742b63](https://github.com/toiroakr/zod-empty/commit/7742b63b90c65d20f5b10da80428e0cbc48c5939))
 
 ## [1.3.1](https://github.com/toiroakr/zod-empty/compare/v1.3.0...v1.3.1) (2025-01-06)
 
-
 ### Bug Fixes
 
-* empty string to null ([14dcff3](https://github.com/toiroakr/zod-empty/commit/14dcff3802b0400b5716139a677156867e642307))
-* empty string to null ([#19](https://github.com/toiroakr/zod-empty/issues/19)) ([cf03084](https://github.com/toiroakr/zod-empty/commit/cf03084680b5a7d113ff5118dc9d5b6ed8b6de8b))
-* test ([183904b](https://github.com/toiroakr/zod-empty/commit/183904b8cdb5ac3288514c1f57632d05e68281e7))
+- empty string to null ([14dcff3](https://github.com/toiroakr/zod-empty/commit/14dcff3802b0400b5716139a677156867e642307))
+- empty string to null ([#19](https://github.com/toiroakr/zod-empty/issues/19)) ([cf03084](https://github.com/toiroakr/zod-empty/commit/cf03084680b5a7d113ff5118dc9d5b6ed8b6de8b))
+- test ([183904b](https://github.com/toiroakr/zod-empty/commit/183904b8cdb5ac3288514c1f57632d05e68281e7))
 
-# [1.3.0](https://github.com/toiroakr/zod-empty/compare/v1.2.2...v1.3.0) (2024-12-30)
-
+## [1.3.0](https://github.com/toiroakr/zod-empty/compare/v1.2.2...v1.3.0) (2024-12-30)
 
 ### Features
 
-* support lazy ([e430e1d](https://github.com/toiroakr/zod-empty/commit/e430e1d10e1305536ce0b55ac384a921802079eb))
+- support lazy ([e430e1d](https://github.com/toiroakr/zod-empty/commit/e430e1d10e1305536ce0b55ac384a921802079eb))
 
 ## [1.2.2](https://github.com/toiroakr/zod-empty/compare/v1.2.1...v1.2.2) (2024-12-29)
 
-
 ### Bug Fixes
 
-* empty string "" ([ae3ce69](https://github.com/toiroakr/zod-empty/commit/ae3ce69cd6af571c601eb8ffdedddb374e2aa4bf))
+- empty string "" ([ae3ce69](https://github.com/toiroakr/zod-empty/commit/ae3ce69cd6af571c601eb8ffdedddb374e2aa4bf))
 
 ## [1.2.1](https://github.com/toiroakr/zod-empty/compare/v1.2.0...v1.2.1) (2024-12-29)
 
-
 ### Bug Fixes
 
-* return value for nullish schema ([30de68e](https://github.com/toiroakr/zod-empty/commit/30de68e2c0ff7841eecd2929410fb1f3d28380e8))
+- return value for nullish schema ([30de68e](https://github.com/toiroakr/zod-empty/commit/30de68e2c0ff7841eecd2929410fb1f3d28380e8))
 
-# [1.2.0](https://github.com/toiroakr/zod-empty/compare/v1.1.1...v1.2.0) (2024-12-29)
-
+## [1.2.0](https://github.com/toiroakr/zod-empty/compare/v1.1.1...v1.2.0) (2024-12-29)
 
 ### Features
 
-* add empty function ([83f1489](https://github.com/toiroakr/zod-empty/commit/83f1489324c1b179aaef0e2576e4700aa2faf961))
+- add empty function ([83f1489](https://github.com/toiroakr/zod-empty/commit/83f1489324c1b179aaef0e2576e4700aa2faf961))
 
 ## [1.1.1](https://github.com/toiroakr/zod-empty/compare/v1.1.0...v1.1.1) (2024-12-28)
 
-
 ### Bug Fixes
 
-* release ([e52f8b5](https://github.com/toiroakr/zod-empty/commit/e52f8b5fcb440066b1f6851a8287a5784f3f10c7))
+- release ([e52f8b5](https://github.com/toiroakr/zod-empty/commit/e52f8b5fcb440066b1f6851a8287a5784f3f10c7))
 
-# [1.1.0](https://github.com/toiroakr/zod-empty/compare/v1.0.7...v1.1.0) (2024-12-28)
-
+## [1.1.0](https://github.com/toiroakr/zod-empty/compare/v1.0.7...v1.1.0) (2024-12-28)
 
 ### Features
 
-* add avoid undefined option (default: true) ([2493756](https://github.com/toiroakr/zod-empty/commit/249375646505c4cf648de0ff79ecaad53194e311))
+- add avoid undefined option (default: true) ([2493756](https://github.com/toiroakr/zod-empty/commit/249375646505c4cf648de0ff79ecaad53194e311))
 
 ## [1.0.7](https://github.com/toiroakr/zod-empty/compare/v1.0.6...v1.0.7) (2024-02-08)
 
-
 ### Bug Fixes
 
-* **package.json:** remove type: "commonjs" ([8e5b270](https://github.com/toiroakr/zod-empty/commit/8e5b2701c2e756518e19890197af34ea2a398957))
+- **package.json:** remove type: "commonjs" ([8e5b270](https://github.com/toiroakr/zod-empty/commit/8e5b2701c2e756518e19890197af34ea2a398957))
 
 ## [1.0.6](https://github.com/toiroakr/zod-empty/compare/v1.0.5...v1.0.6) (2022-08-08)
 
-
 ### Bug Fixes
 
-* build before release. ([c26ef7d](https://github.com/toiroakr/zod-empty/commit/c26ef7d72712b38745103d814532f7bf1050da35))
+- build before release. ([c26ef7d](https://github.com/toiroakr/zod-empty/commit/c26ef7d72712b38745103d814532f7bf1050da35))
 
 ## [1.0.5](https://github.com/toiroakr/zod-empty/compare/v1.0.4...v1.0.5) (2022-08-05)
 
-
 ### Bug Fixes
 
-* return type. ([0b4bd54](https://github.com/toiroakr/zod-empty/commit/0b4bd54d4948ed503f932d2180a05255b5dedc65))
+- return type. ([0b4bd54](https://github.com/toiroakr/zod-empty/commit/0b4bd54d4948ed503f932d2180a05255b5dedc65))
 
 ## [1.0.4](https://github.com/toiroakr/zod-empty/compare/v1.0.3...v1.0.4) (2022-08-05)
 
-
 ### Bug Fixes
 
-* default method for function schema. ([fa98db3](https://github.com/toiroakr/zod-empty/commit/fa98db38e427395d1ea37a6be667bdfd9373a7aa))
+- default method for function schema. ([fa98db3](https://github.com/toiroakr/zod-empty/commit/fa98db38e427395d1ea37a6be667bdfd9373a7aa))
 
 ## [1.0.3](https://github.com/toiroakr/zod-empty/compare/v1.0.2...v1.0.3) (2022-08-05)
 
-
 ### Bug Fixes
 
-* default returns cloned value. ([7d7cc6c](https://github.com/toiroakr/zod-empty/commit/7d7cc6cfefa056f5befaf5cd25abb86b63b82763))
+- default returns cloned value. ([7d7cc6c](https://github.com/toiroakr/zod-empty/commit/7d7cc6cfefa056f5befaf5cd25abb86b63b82763))
 
 ## [1.0.2](https://github.com/toiroakr/zod-empty/compare/v1.0.1...v1.0.2) (2022-08-05)
 
-
 ### Bug Fixes
 
-* remove dependency. ([de6f6b1](https://github.com/toiroakr/zod-empty/commit/de6f6b198d9c4674f27a1b2b26dbd6a2ec0a7437))
+- remove dependency. ([de6f6b1](https://github.com/toiroakr/zod-empty/commit/de6f6b198d9c4674f27a1b2b26dbd6a2ec0a7437))
 
 ## [1.0.1](https://github.com/toiroakr/zod-empty/compare/v1.0.0...v1.0.1) (2022-08-05)
 
-
 ### Bug Fixes
 
-* number with min/max. ([d4fb129](https://github.com/toiroakr/zod-empty/commit/d4fb129b56b4189254a6a373b8f56edfe2f3ed26))
+- number with min/max. ([d4fb129](https://github.com/toiroakr/zod-empty/commit/d4fb129b56b4189254a6a373b8f56edfe2f3ed26))
 
-# 1.0.0 (2022-08-05)
-
+## 1.0.0 (2022-08-05)
 
 ### Features
 
-* initial release ([cb778a0](https://github.com/toiroakr/zod-empty/commit/cb778a0daf6a4e47c2368e7cde7d2d81e63d8f20))
+- initial release ([cb778a0](https://github.com/toiroakr/zod-empty/commit/cb778a0daf6a4e47c2368e7cde7d2d81e63d8f20))


### PR DESCRIPTION
## Summary

`CHANGELOG.md` was still in semantic-release format, and it broke the changesets release PR (#45):

- The file opened with `# [2.1.0](...)`, and every minor/major release used an H1 heading. Changesets treats the first line as the package title and inserts `## <version>` immediately after it, so the new entry ended up nested under 2.1.0 — making 2.1.0's own `### Bug Fixes` / `### Features` look like they belonged to the new version.
- The changelog extractor in changesets/action slices from `## <version>` to the next heading *of the same depth*. The depth-1 `# [1.5.0]` heading was therefore not treated as a terminator, and the release PR body swallowed all of 2.1.0 plus the entire 1.5.0 section.

Changes:

- Add a `# zod-empty` H1 title line.
- Demote the seven H1 version headings (2.1.0, 1.5.0, 1.4.0, 1.3.0, 1.2.0, 1.1.0, 1.0.0) to H2, matching the H2 headings the patch releases already use.
- Reformat with prettier 2.8.8 — the version `@changesets/cli` bundles — so `changeset version` no longer rewrites the whole file (the last release PR carried a 130-line reformatting diff).

## Verification

Running `pnpm exec changeset version` locally on this branch now produces a single addition: the `## 2.2.0` section directly below the title, with the rest of the file untouched. The version bump and changeset consumption were reverted and are not part of this commit.

## Notes

- No changeset is included: `CHANGELOG.md` is not listed in `files` in `package.json`, so this change does not reach consumers.
- Once this lands on main, the Release workflow regenerates `changeset-release/main`, and the body of #45 will contain only the 2.2.0 entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted the changelog using consistent GitHub-style Markdown headings, bullets, and spacing.
  * Preserved all existing release history and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->