### PR TITLE
chore: use version ranges for dependencies/devDependencies and bump them via renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,19 +34,19 @@
   },
   "homepage": "https://github.com/toiroakr/zod-empty#readme",
   "dependencies": {
-    "just-clone": "6.2.0"
+    "just-clone": "^6.2.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "1.9.4",
+    "@biomejs/biome": "^1.9.4",
     "@changesets/cli": "^2.31.1",
     "@vitest/coverage-v8": "^2.1.8",
-    "@vitest/ui": "2.1.8",
+    "@vitest/ui": "^2.1.8",
     "lefthook": "^1.10.1",
     "pkg-pr-new": "^0.0.41",
     "tsdown": "^0.21.7",
-    "typescript": "6.0.2",
-    "vitest": "2.1.8",
-    "vitest-github-actions-reporter": "0.11.1",
+    "typescript": "^6.0.2",
+    "vitest": "^2.1.8",
+    "vitest-github-actions-reporter": "^0.11.1",
     "zod": "^4.0.5"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       just-clone:
-        specifier: 6.2.0
+        specifier: ^6.2.0
         version: 6.2.0
     devDependencies:
       '@biomejs/biome':
-        specifier: 1.9.4
+        specifier: ^1.9.4
         version: 1.9.4
       '@changesets/cli':
         specifier: ^2.31.1
@@ -22,7 +22,7 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(supports-color@7.2.0)(vitest@2.1.8)
       '@vitest/ui':
-        specifier: 2.1.8
+        specifier: ^2.1.8
         version: 2.1.8(vitest@2.1.8)
       lefthook:
         specifier: ^1.10.1
@@ -34,13 +34,13 @@ importers:
         specifier: ^0.21.7
         version: 0.21.10(typescript@6.0.2)
       typescript:
-        specifier: 6.0.2
+        specifier: ^6.0.2
         version: 6.0.2
       vitest:
-        specifier: 2.1.8
+        specifier: ^2.1.8
         version: 2.1.8(@vitest/ui@2.1.8)(supports-color@7.2.0)
       vitest-github-actions-reporter:
-        specifier: 0.11.1
+        specifier: ^0.11.1
         version: 0.11.1(vitest@2.1.8)
       zod:
         specifier: ^4.0.5

--- a/renovate.json
+++ b/renovate.json
@@ -4,10 +4,12 @@
   "labels": ["dependencies"],
   "minimumReleaseAge": "7 days",
   "prConcurrentLimit": 5,
+  "rangeStrategy": "bump",
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],
-      "automerge": true
+      "automerge": true,
+      "rangeStrategy": "bump"
     },
     {
       "groupName": "testing",


### PR DESCRIPTION
## Summary

- Switch the remaining exact-pinned `dependencies`/`devDependencies` to caret ranges (`just-clone`, `@biomejs/biome`, `@vitest/ui`, `typescript`, `vitest`, `vitest-github-actions-reporter`).
- Set renovate's `rangeStrategy` to `bump` at the top level, and explicitly on the `devDependencies` packageRule (a top-level `rangeStrategy` is outranked by any matching packageRule, so the explicit override guards against that).
- Refreshed `pnpm-lock.yaml`: only `specifier` fields changed, all resolved versions are unchanged.

No changeset: this only changes dependency ranges and how renovate proposes future updates, not any published artifact's behavior.

Ported from the same change in toiroakr/vinfer#2.

Note: this repository already has a `.changeset` directory and the `APP_ID`/`APP_PRIVATE_KEY` secrets used by toiroakr/vinfer's Renovate auto-changeset workflow (toiroakr/vinfer#3), which wasn't in scope for this change but could be ported here too in a follow-up.