### PR TITLE
ci: verify peerDependencies floor versions in CI

### DIFF
--- a/.changeset/verify-peer-deps-floor.md
+++ b/.changeset/verify-peer-deps-floor.md
@@ -1,0 +1,5 @@
+---
+"zod-empty": patch
+---
+
+Verify peerDependencies lower bounds against real installs in CI and normalize the `typescript` range to `>=5.0.0` (was the equivalent but unconventional `>=5.x`). The `zod` floor (`4.x`, i.e. `>=4.0.0`) was verified accurate as-is.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,10 +20,10 @@ jobs:
         node-version: [22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
@@ -35,3 +35,38 @@ jobs:
         if: startsWith(${{ matrix.node-version }}, '16.')
         # FIXME: This is a workaround for comment on PRs from forks
         continue-on-error: true
+
+  peer-floor:
+    name: peer-floor (${{ matrix.name }})
+    runs-on: ubuntu-latest
+
+    # Verifies the peerDependencies lower bounds declared in package.json
+    # (zod, typescript) actually install and pass build+test, since Renovate
+    # only ever widens peerDependencies ranges and never installs the floor.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: zod floor
+            zod: "4.0.0"
+          - name: typescript floor
+            typescript: "5.0.2"
+          - name: zod + typescript floor
+            zod: "4.0.0"
+            typescript: "5.0.2"
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.x
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - name: Install peerDependencies floor versions
+        run: |
+          set -eo pipefail
+          if [ -n "${{ matrix.zod }}" ]; then pnpm add -D zod@${{ matrix.zod }}; fi
+          if [ -n "${{ matrix.typescript }}" ]; then pnpm add -D typescript@${{ matrix.typescript }}; fi
+      - run: pnpm build
+      - run: pnpm test -- --run

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "zod": "^4.0.5"
   },
   "peerDependencies": {
-    "typescript": ">=5.x",
+    "typescript": ">=5.0.0",
     "zod": "4.x"
   },
   "files": [


### PR DESCRIPTION
## Summary

- Add a `peer-floor` matrix job to `.github/workflows/test.yaml` (pull_request-triggered) that installs the declared `zod` (4.0.0) and `typescript` (5.0.2, the lowest published release satisfying `>=5.0.0`) peerDependencies lower bounds and runs `pnpm build` + `pnpm test -- --run` against each combination (zod alone, typescript alone, both together). This is a new job on the existing PR-triggered `Test` workflow, not a new workflow file, since a PR-triggered CI already existed.
- Both floors were verified locally against the real installs and passed build+test (and a consumer-style `strict`/`Bundler`-resolution type-check), so no `peerDependencies` value needed correcting.
- Normalize `typescript` from the unconventional `>=5.x` to the equivalent `>=5.0.0` (`node-semver` confirms both ranges resolve identically; only the notation changed).
- Add a patch changeset since this PR changes the published `peerDependencies` field.

## Notes

- Renovate's `rangeStrategy` is `"bump"` at the top level of `renovate.json`, but the npm manager hardcodes `widen` for `peerDependencies` regardless of that setting, so peerDependencies ranges are not at risk of being narrowed by Renovate here — no `renovate.json` change was needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the minimum supported TypeScript version to `5.0.0`.
  - Verified compatibility with the minimum supported TypeScript and Zod versions.

- **Chores**
  - Improved CI reliability by pinning workflow actions to specific versions.
  - Added automated checks for supported peer-dependency version combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->