### PR TITLE
fix: scope Renovate rangeStrategy per depType, pin devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,17 +37,17 @@
     "just-clone": "^6.2.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
-    "@changesets/cli": "^2.31.1",
-    "@vitest/coverage-v8": "^2.1.8",
-    "@vitest/ui": "^2.1.8",
-    "lefthook": "^1.10.1",
-    "pkg-pr-new": "^0.0.41",
-    "tsdown": "^0.21.7",
-    "typescript": "^6.0.2",
-    "vitest": "^2.1.8",
-    "vitest-github-actions-reporter": "^0.11.1",
-    "zod": "^4.0.5"
+    "@biomejs/biome": "1.9.4",
+    "@changesets/cli": "2.31.1",
+    "@vitest/coverage-v8": "2.1.9",
+    "@vitest/ui": "2.1.8",
+    "lefthook": "1.13.6",
+    "pkg-pr-new": "0.0.41",
+    "tsdown": "0.21.10",
+    "typescript": "6.0.2",
+    "vitest": "2.1.8",
+    "vitest-github-actions-reporter": "0.11.1",
+    "zod": "4.4.3"
   },
   "peerDependencies": {
     "typescript": ">=5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,37 +13,37 @@ importers:
         version: 6.2.0
     devDependencies:
       '@biomejs/biome':
-        specifier: ^1.9.4
+        specifier: 1.9.4
         version: 1.9.4
       '@changesets/cli':
-        specifier: ^2.31.1
+        specifier: 2.31.1
         version: 2.31.1
       '@vitest/coverage-v8':
-        specifier: ^2.1.8
+        specifier: 2.1.9
         version: 2.1.9(supports-color@7.2.0)(vitest@2.1.8)
       '@vitest/ui':
-        specifier: ^2.1.8
+        specifier: 2.1.8
         version: 2.1.8(vitest@2.1.8)
       lefthook:
-        specifier: ^1.10.1
+        specifier: 1.13.6
         version: 1.13.6
       pkg-pr-new:
-        specifier: ^0.0.41
+        specifier: 0.0.41
         version: 0.0.41
       tsdown:
-        specifier: ^0.21.7
+        specifier: 0.21.10
         version: 0.21.10(typescript@6.0.2)
       typescript:
-        specifier: ^6.0.2
+        specifier: 6.0.2
         version: 6.0.2
       vitest:
-        specifier: ^2.1.8
+        specifier: 2.1.8
         version: 2.1.8(@vitest/ui@2.1.8)(supports-color@7.2.0)
       vitest-github-actions-reporter:
-        specifier: ^0.11.1
+        specifier: 0.11.1
         version: 0.11.1(vitest@2.1.8)
       zod:
-        specifier: ^4.0.5
+        specifier: 4.4.3
         version: 4.4.3
 
 packages:

--- a/renovate.json
+++ b/renovate.json
@@ -5,12 +5,20 @@
   "gitIgnoredAuthors": ["271965483+toiroakr-release-bot[bot]@users.noreply.github.com"],
   "minimumReleaseAge": "7 days",
   "prConcurrentLimit": 5,
-  "rangeStrategy": "bump",
+  "rangeStrategy": "auto",
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],
       "automerge": true,
+      "rangeStrategy": "pin"
+    },
+    {
+      "matchDepTypes": ["dependencies"],
       "rangeStrategy": "bump"
+    },
+    {
+      "matchDepTypes": ["peerDependencies"],
+      "automerge": false
     },
     {
       "groupName": "testing",


### PR DESCRIPTION
## Summary

- The top-level `"rangeStrategy": "bump"` in `renovate.json` applied to every depType, including `peerDependencies`. Renovate's own default only widens `peerDependencies` (`rangeStrategy: "auto"` -> effectively `"widen"`); an explicit `"bump"` overrides that built-in safeguard, so every devDependency bump also mechanically raised the `peerDependencies` lower bounds (`typescript`, `zod`).
- Changed top-level `rangeStrategy` from `"bump"` to `"auto"`.
- Added a `peerDependencies` packageRule with `automerge: false` (rangeStrategy falls back to the `"auto"` -> `"widen"` default, so peer lower bounds are never silently narrowed).
- Added a `dependencies` packageRule with `rangeStrategy: "bump"` (preserves prior behavior for the `just-clone` runtime dependency).
- Changed the `devDependencies` packageRule's `rangeStrategy` from `"bump"` to `"pin"` (still `automerge: true`), and pinned `package.json` devDependencies to the exact versions already resolved in `pnpm-lock.yaml`.

This mirrors the same fix already applied in the sibling projects `zinfer` and `vinfer`, where the same top-level `rangeStrategy: "bump"` was found to narrow `peerDependencies` lower bounds.

No changeset is included: this change only affects Renovate config and devDependency version pinning, neither of which reaches npm package consumers.
